### PR TITLE
Fix drafts published automatically

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    webflow-rb (1.1.0)
+    webflow-rb (1.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/webflow/client.rb
+++ b/lib/webflow/client.rb
@@ -73,7 +73,7 @@ module Webflow
 
     def create_item(collection_id, data, is_draft: false, is_archived: false)
       result = post("/collections/#{collection_id}/items", { isArchived: is_archived, isDraft: is_draft, fieldData: data })
-      publish_item(collection_id, result.fetch(:id)) unless is_draft
+      publish_item(collection_id, result.fetch(:id)) unless result[:isDraft]
       result
     end
 

--- a/lib/webflow/client.rb
+++ b/lib/webflow/client.rb
@@ -73,7 +73,7 @@ module Webflow
 
     def create_item(collection_id, data, is_draft: false, is_archived: false)
       result = post("/collections/#{collection_id}/items", { isArchived: is_archived, isDraft: is_draft, fieldData: data })
-      publish_item(collection_id, result.fetch(:id))
+      publish_item(collection_id, result.fetch(:id)) unless is_draft
       result
     end
 
@@ -82,7 +82,7 @@ module Webflow
         "/collections/#{collection_id}/items/#{item_id}",
         { isArchived: is_archived, isDraft: is_draft, fieldData: data }.compact
       )
-      publish_item(collection_id, item_id)
+      publish_item(collection_id, item_id) unless result[:isDraft]
       result
     end
 

--- a/lib/webflow/version.rb
+++ b/lib/webflow/version.rb
@@ -1,3 +1,3 @@
 module Webflow
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.1.1'.freeze
 end

--- a/test/fixtures/cassettes/test_it_creates_drafts_and_archives.yml
+++ b/test/fixtures/cassettes/test_it_creates_drafts_and_archives.yml
@@ -49,52 +49,6 @@ http_interactions:
         Item Name ABC","slug":"test-item-name-abc-df1d4"}}'
   recorded_at: Tue, 05 Dec 2023 16:31:17 GMT
 - request:
-    method: post
-    uri: https://api.webflow.com/v2/collections/655276efe9424bcefd3231a2/items/publish
-    body:
-      encoding: ASCII-8BIT
-      string: '{"itemIds":["656f50556fbd03baed77208e"]}'
-    headers:
-      Authorization:
-      - Bearer <TEST_API_TOKEN>
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.webflow.com
-      User-Agent:
-      - http.rb/5.1.1
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 05 Dec 2023 16:31:19 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '61'
-      Connection:
-      - close
-      Etag:
-      - W/"3d-wRzzyQ4KqwXX39dftDu/ckNMqYw"
-      Retry-After:
-      - '46'
-      X-Ratelimit-Limit:
-      - '60'
-      X-Ratelimit-Remaining:
-      - '46'
-      X-Response-Time:
-      - 1191.940ms
-    body:
-      encoding: UTF-8
-      string: '{"publishedItemIds":["656f50556fbd03baed77208e"],"errors":[]}'
-  recorded_at: Tue, 05 Dec 2023 16:31:19 GMT
-- request:
     method: patch
     uri: https://api.webflow.com/v2/collections/655276efe9424bcefd3231a2/items/656f50556fbd03baed77208e
     body:
@@ -139,50 +93,4 @@ http_interactions:
       string: '{"id":"656f50556fbd03baed77208e","cmsLocaleId":"655276ef2d7dfc2d8eef35a0","lastPublished":"2023-12-05T16:31:18.800Z","lastUpdated":"2023-12-05T16:31:20.609Z","createdOn":"2023-12-05T16:31:17.859Z","isArchived":true,"isDraft":true,"fieldData":{"name":"Test
         Item Name Update DEF","slug":"test-item-name-abc-df1d4"}}'
   recorded_at: Tue, 05 Dec 2023 16:31:20 GMT
-- request:
-    method: post
-    uri: https://api.webflow.com/v2/collections/655276efe9424bcefd3231a2/items/publish
-    body:
-      encoding: ASCII-8BIT
-      string: '{"itemIds":["656f50556fbd03baed77208e"]}'
-    headers:
-      Authorization:
-      - Bearer <TEST_API_TOKEN>
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.webflow.com
-      User-Agent:
-      - http.rb/5.1.1
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 05 Dec 2023 16:31:19 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '61'
-      Connection:
-      - close
-      Etag:
-      - W/"3d-wRzzyQ4KqwXX39dftDu/ckNMqYw"
-      Retry-After:
-      - '46'
-      X-Ratelimit-Limit:
-      - '60'
-      X-Ratelimit-Remaining:
-      - '46'
-      X-Response-Time:
-      - 1191.940ms
-    body:
-      encoding: UTF-8
-      string: '{"publishedItemIds":["656f50556fbd03baed77208e"],"errors":[]}'
-  recorded_at: Tue, 05 Dec 2023 16:31:19 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
When calling`create_item` and `update_item`we avoid publishing when the resulting webflow object is a draft.

I should have caught this when submitting my last PR https://github.com/vfonic/webflow-rb/pull/1 my bad!

But this change is also necessary to be able to create drafts, as at the moment we're calling publish after creating the object, and that removes the draft state.

LMK if this looks ok @vfonic 
