### PR TITLE
Adding Rate Limit Handling to Client

### DIFF
--- a/lib/webflow/error.rb
+++ b/lib/webflow/error.rb
@@ -1,6 +1,6 @@
 module Webflow
   class Error < StandardError
-    attr_reader :data
+    attr_reader :data, :response
 
     def initialize(data)
       @data = data
@@ -17,4 +17,6 @@ module Webflow
       data[:details]
     end
   end
+
+  class RateLimitError < Error; end
 end

--- a/test/fixtures/cassettes/test_it_raises_rate_limit_errors.yml
+++ b/test/fixtures/cassettes/test_it_raises_rate_limit_errors.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.webflow.com/v2/sites
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        Authorization:
+          - Bearer <TEST_API_TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 429
+        message: Too Many Requests
+      headers:
+        Date:
+          - Tue, 14 Jan 2025 19:14:46 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "96"
+        Connection:
+          - keep-alive
+        Etag:
+          - W/"60-DpTm+bsK1EMeVvVQjd2eOIvXDxo"
+        Retry-After:
+          - "1"
+        X-Ratelimit-Limit:
+          - "60"
+        X-Ratelimit-Remaining:
+          - "0"
+        X-Response-Time:
+          - 20.426ms
+      body:
+        encoding: UTF-8
+        string: '{"message":"Too Many Requests","code":"too_many_requests","externalReference":null,"details":[]}'
+    recorded_at: Tue, 14 Jan 2025 19:14:46 GMT
+  - request:
+      method: get
+      uri: https://api.webflow.com/v2/sites
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        Authorization:
+          - Bearer <TEST_API_TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 429
+        message: Too Many Requests
+      headers:
+        Date:
+          - Tue, 14 Jan 2025 19:14:46 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "96"
+        Connection:
+          - keep-alive
+        Etag:
+          - W/"60-DpTm+bsK1EMeVvVQjd2eOIvXDxo"
+        Retry-After:
+          - "1"
+        X-Ratelimit-Limit:
+          - "60"
+        X-Ratelimit-Remaining:
+          - "0"
+        X-Response-Time:
+          - 20.426ms
+      body:
+        encoding: UTF-8
+        string: '{"message":"Too Many Requests","code":"too_many_requests","externalReference":null,"details":[]}'
+    recorded_at: Tue, 14 Jan 2025 19:14:46 GMT
+recorded_with: VCR 6.3.1

--- a/test/webflow_client_test.rb
+++ b/test/webflow_client_test.rb
@@ -16,4 +16,14 @@ class WebflowClientTest < Minitest::Test
 
     assert_equal('api_token', client.instance_variable_get('@token'))
   end
+
+  def test_it_raises_rate_limit_errors
+    VCR.use_cassette('test_it_raises_rate_limit_errors') do
+      client = Webflow::Client.new(ENV.fetch('TEST_API_TOKEN'))
+      # Retries once and fails after that
+      assert_raises(Webflow::RateLimitError) do
+        client.sites
+      end
+    end
+  end
 end


### PR DESCRIPTION
If it picks up a 429, it sleeps the seconds described in "Retry-After". The client makes one more request and if it fails, it raises a RateLimitError.

[Webflow's Documentation](https://developers.webflow.com/v2.0.0/data/reference/rate-limits)