### PR TITLE
Add query parameter support to list_items method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    webflow-rb (1.1.2)
+    webflow-rb (1.1.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/webflow/client.rb
+++ b/lib/webflow/client.rb
@@ -41,9 +41,9 @@ module Webflow
     #     total:  total # of items in the collection
     #   }
     # }
-    def list_items(collection_id, limit: PAGINATION_LIMIT, offset: 0)
+    def list_items(collection_id, limit: PAGINATION_LIMIT, offset: 0, query_params: {})
       limit = [limit, PAGINATION_LIMIT].min
-      get("/collections/#{collection_id}/items", { limit: limit, offset: offset }).fetch(:items)
+      get("/collections/#{collection_id}/items", query_params.merge(limit: limit, offset: offset)).fetch(:items)
     end
 
     def list_all_items(collection_id) # rubocop:disable Metrics/MethodLength

--- a/lib/webflow/version.rb
+++ b/lib/webflow/version.rb
@@ -1,3 +1,3 @@
 module Webflow
-  VERSION = '1.1.2'.freeze
+  VERSION = '1.1.3'.freeze
 end

--- a/test/fixtures/cassettes/test_it_filters_items_with_query_params.yml
+++ b/test/fixtures/cassettes/test_it_filters_items_with_query_params.yml
@@ -1,0 +1,141 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.webflow.com/v2/collections/655276efe9424bcefd3231a2/items
+      body:
+        encoding: UTF-8
+        string: '{"isArchived":false,"isDraft":true,"fieldData":{"name":"Test 1"}}'
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        Authorization:
+          - Bearer <TEST_API_TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 202
+        message: Accepted
+      headers:
+        Date:
+          - Tue, 18 Mar 2025 16:16:26 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "255"
+        Connection:
+          - keep-alive
+        Etag:
+          - W/"ff-84nvIv+ehh6GrdjGZ3vsUdnQEnc"
+        Retry-After:
+          - "60"
+        X-Ratelimit-Limit:
+          - "120"
+        X-Ratelimit-Remaining:
+          - "119"
+        X-Response-Time:
+          - 725.493ms
+      body:
+        encoding: UTF-8
+        string:
+          '{"id":"67d99c5a194c7a4bd435cbc5","cmsLocaleId":"655276ef2d7dfc2d8eef35a0","lastPublished":null,"lastUpdated":"2025-03-18T16:16:26.270Z","createdOn":"2025-03-18T16:16:26.270Z","isArchived":false,"isDraft":true,"fieldData":{"name":"Test
+          1","slug":"test-1"}}'
+    recorded_at: Tue, 18 Mar 2025 16:16:26 GMT
+  - request:
+      method: post
+      uri: https://api.webflow.com/v2/collections/655276efe9424bcefd3231a2/items
+      body:
+        encoding: UTF-8
+        string: '{"isArchived":false,"isDraft":true,"fieldData":{"name":"Test 2"}}'
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        Authorization:
+          - Bearer <TEST_API_TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 202
+        message: Accepted
+      headers:
+        Date:
+          - Tue, 18 Mar 2025 16:16:27 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "255"
+        Connection:
+          - keep-alive
+        Etag:
+          - W/"ff-XjU6kWn5dRXSpjWt0ytqirbQSfk"
+        Retry-After:
+          - "59"
+        X-Ratelimit-Limit:
+          - "120"
+        X-Ratelimit-Remaining:
+          - "118"
+        X-Response-Time:
+          - 635.673ms
+      body:
+        encoding: UTF-8
+        string:
+          '{"id":"67d99c5b994bb5307d3f83cb","cmsLocaleId":"655276ef2d7dfc2d8eef35a0","lastPublished":null,"lastUpdated":"2025-03-18T16:16:27.638Z","createdOn":"2025-03-18T16:16:27.638Z","isArchived":false,"isDraft":true,"fieldData":{"name":"Test
+          2","slug":"test-2"}}'
+    recorded_at: Tue, 18 Mar 2025 16:16:27 GMT
+  - request:
+      method: get
+      uri: https://api.webflow.com/v2/collections/655276efe9424bcefd3231a2/items?limit=100&name=Test%201&offset=0
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        Authorization:
+          - Bearer <TEST_API_TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Tue, 18 Mar 2025 16:16:28 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "315"
+        Connection:
+          - keep-alive
+        Etag:
+          - W/"13b-ZJkvP0KXhZfxpezqWleoBW3D8nU"
+        Retry-After:
+          - "58"
+        X-Ratelimit-Limit:
+          - "120"
+        X-Ratelimit-Remaining:
+          - "117"
+        X-Response-Time:
+          - 133.593ms
+      body:
+        encoding: UTF-8
+        string:
+          '{"items":[{"id":"67d99c5a194c7a4bd435cbc5","cmsLocaleId":"655276ef2d7dfc2d8eef35a0","lastPublished":null,"lastUpdated":"2025-03-18T16:16:26.270Z","createdOn":"2025-03-18T16:16:26.270Z","isArchived":false,"isDraft":true,"fieldData":{"name":"Test
+          1","slug":"test-1"}}],"pagination":{"limit":100,"offset":0,"total":1}}'
+    recorded_at: Tue, 18 Mar 2025 16:16:28 GMT
+recorded_with: VCR 6.2.0

--- a/test/webflow_test.rb
+++ b/test/webflow_test.rb
@@ -47,6 +47,18 @@ class WebflowTest < Minitest::Test
     end
   end
 
+  def test_it_filters_items_with_query_params
+    VCR.use_cassette('test_it_filters_items_with_query_params') do
+      CLIENT.create_item(COLLECTION_ID, { name: 'Test 1' }, is_draft: true)
+      CLIENT.create_item(COLLECTION_ID, { name: 'Test 2' }, is_draft: true)
+
+      items = CLIENT.list_items(COLLECTION_ID, query_params: { name: 'Test 1' })
+
+      assert_equal(1, items.length)
+      assert_equal('Test 1', items.first.dig(:fieldData, :name))
+    end
+  end
+
   def test_it_lists_all_items
     VCR.use_cassette('test_it_lists_all_items') do
       CLIENT.list_all_items(COLLECTION_ID) do |items|


### PR DESCRIPTION
The [list collection items](https://developers.webflow.com/v2.0.0/data/reference/cms/collection-items/staged-items/list-items) endpoint supports query parameters, which can be useful when searching for a specific item in a collection by a field other than its Webflow ID.

This PR introduces a query_params: argument, allowing queries like:

```rb
my_item = CLIENT.list_items(@collection_id, query_params: { external_id: 'my-item-external-id' })
```

**Note:** Since `offset` and `limit` are also query parameters and explicitly included in the method signature, they take precedence over any values in the `query_params:` hash.